### PR TITLE
12th_class/schema_validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
     "eslint-plugin-prettier": "^4.2.1",
+    "joi": "^17.6.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0"

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
 import { HttpModule, HttpService } from '@nestjs/axios';
+import { lastValueFrom } from 'rxjs';
+import { ConfigModule } from '@nestjs/config';
+import * as Joi from 'joi';
+
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { UsersModule } from './users/users.module';
 import { ProductsModule } from './products/products.module';
-import { lastValueFrom } from 'rxjs';
 import { DatabaseModule } from './database/database.module';
-import { ConfigModule } from '@nestjs/config';
 import { enviroments } from './enviroments';
 import config from './config';
 @Module({
@@ -15,6 +17,11 @@ import config from './config';
 			envFilePath: enviroments[process.env.NODE_ENV] || '.env',
 			isGlobal: true,
 			load: [config],
+			validationSchema: Joi.object({
+				API_KEY: Joi.number().required(),
+				DATABASE_NAME: Joi.string().required(),
+				DATABASE_PORT: Joi.number().required(),
+			}),
 		}),
 		HttpModule,
 		UsersModule,


### PR DESCRIPTION
## Validación de esquemas en .envs con Joi

Se recomienda validad esquemas, en este caso con Joi, para blindar la aplicación de errores en desarrollo y de inyección de variables de ambiente por parte de DevOps.

Comando de instalación: npm install --save joi